### PR TITLE
Removing System.exit() calls as they interfere with spark Execution

### DIFF
--- a/src/main/java/org/commoncrawl/spark/examples/CCIndexExport.java
+++ b/src/main/java/org/commoncrawl/spark/examples/CCIndexExport.java
@@ -195,7 +195,6 @@ public class CCIndexExport {
 	public static void main(String[] args) throws IOException {
 		CCIndexExport job = new CCIndexExport();
 		int success = job.run(args);
-		System.exit(success);
 	}
 
 }

--- a/src/main/java/org/commoncrawl/spark/examples/CCIndexWarcExport.java
+++ b/src/main/java/org/commoncrawl/spark/examples/CCIndexWarcExport.java
@@ -212,7 +212,6 @@ public class CCIndexWarcExport extends CCIndexExport {
 	public static void main(String[] args) throws IOException {
 		CCIndexExport job = new CCIndexWarcExport();
 		int success = job.run(args);
-		System.exit(success);
 	}
 
 }


### PR DESCRIPTION
I built the spark app and tried to run it on AWS EMR. However, I encountered a strange error where all the warc files were generated twice. 

Upon investigating, I found that Spark does not play nice with System.exit() and will mark the job as FAILED after retrying it once. 

https://github.com/apache/spark/blob/a829234df35c87c169425f2c79fd1963b5420888/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala#L238

Thus, it is better to remove the System.exit() call at the end.