### PR TITLE
Upgrade to Spark 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Not part of this project. Please have a look at [cc-pyspark](//github.com/common
 A Spark job converts the Common Crawl URL index files (a [sharded gzipped index](https://pywb.readthedocs.io/en/latest/manual/indexing.html#zipnum-sharded-index) in [CDXJ format](https://iipc.github.io/warc-specifications/specifications/cdx-format/openwayback-cdxj/)) into a table in [Parquet](https://parquet.apache.org/) or [ORC](https://orc.apache.org/) format.
 
 ```
-> APPJAR=target/cc-index-table-0.2-SNAPSHOT-jar-with-dependencies.jar
+> APPJAR=target/cc-index-table-0.3-SNAPSHOT-jar-with-dependencies.jar
 > $SPARK_HOME/bin/spark-submit --class org.commoncrawl.spark.CCIndex2Table $APPJAR
 
 CCIndex2Table [options] <inputPathSpec> <outputPath>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.commoncrawl</groupId>
 	<artifactId>cc-index-table</artifactId>
-	<version>0.2-SNAPSHOT</version>
+	<version>0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>cc-index-table</name>
@@ -14,7 +14,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 
-		<spark.version>2.4.6</spark.version>
+		<spark.version>3.2.0</spark.version>
 		<spark.core.version>2.12</spark.core.version>
 
 		<slf4j-api.version>1.7.30</slf4j-api.version>

--- a/src/script/convert_url_index.sh
+++ b/src/script/convert_url_index.sh
@@ -31,7 +31,7 @@ SPARK_EXTRA_OPTS="${SPARK_EXTRA_OPTS:-""}"
 test -e $(dirname $0)/convert_url_index_conf.sh && . $(dirname $0)/convert_url_index_conf.sh
 
 
-_APPJAR=$PWD/target/cc-index-table-0.2-SNAPSHOT-jar-with-dependencies.jar
+_APPJAR=$PWD/target/cc-index-table-0.3-SNAPSHOT-jar-with-dependencies.jar
 
 
 


### PR DESCRIPTION
... and increment version number (0.2 -> 0.3)

Spark [3.2.0](https://spark.apache.org/releases/spark-release-3-2-0.html) ships with an upgrade of parquet-mr [1.12.1](https://github.com/apache/parquet-mr/blob/apache-parquet-1.12.1/CHANGES.md) (from 1.10.1). Notable improvements by the Parquet upgrade are:
- bloom filters ([PARQUET-41](https://issues.apache.org/jira/browse/PARQUET-41))
- column-wise configuration ([PARQUET-1784](https://issues.apache.org/jira/browse/PARQUET-1784))
- direct integration of [Zstandard compression](https://en.wikipedia.org/wiki/Zstandard) ([PARQUET-1866](https://issues.apache.org/jira/browse/PARQUET-1866))

Upgrading to Spark 3.2.0 makes it possible to explore whether these (and other) features can be utilized, granted they are supported or at least, do not break using the columnar index on Athena, Spark and Hive.