### PR TITLE
Column with host name reverse domain name notation

### DIFF
--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -117,12 +117,18 @@ public class HostName {
 		return revHost;
 	}
 
+	public String getHostNameReversed() {
+		if (revHost == null)
+			return null;
+		return String.join(".", revHost);
+	}
+
 	/**
-	 * Split host name into parts in reverse order: www.example.com becomes [com,
-	 * example, www].
+	 * Split host name into parts in reverse order: <code>www.example.com</code>
+	 * becomes <code>[com,example, www]</code>.
 	 * 
 	 * @param hostName
-	 * @return parts of hostname in reverse order
+	 * @return parts of host name in reverse order
 	 */
 	public static String[] reverseHost(String hostName) {
 		String[] rev = SPLIT_HOST_PATTERN.split(hostName);
@@ -139,11 +145,12 @@ public class HostName {
 	 * otherwise specified):
 	 * <ol>
 	 * <li>host name
-	 * <li>reverse host (array of strings: [com, example, www])
+	 * <li>parts 1 - 5 of the reversed host name (first part is the top-level domain)
 	 * <li>registry suffix
 	 * <li>domain name below registry suffix
 	 * <li>private suffix
 	 * <li>domain name below private suffix
+	 * <li>reversed host name (com.example.www)
 	 * </ol>
 	 * Reverse host is null if the host name is an IP address. Domain name and
 	 * suffixes are null if the host name is an IP address, or if no valid suffix is
@@ -162,8 +169,8 @@ public class HostName {
 				getRegistrySuffix(),
 				getDomainNameUnderRegistrySuffix(),
 				getPrivateSuffix(),
-				getPrivateDomainName()
+				getPrivateDomainName(),
+				getHostNameReversed()
 				);
 	}
-
 }

--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -185,6 +185,7 @@ public class CCIndex2Table {
 					h.get(4), h.get(5),
 					h.get(6), h.get(7),
 					h.get(8), h.get(9),
+					h.get(10),
 					// URL components
 					u.getUrl().getProtocol(),
 					(u.getUrl().getPort() != -1 ? u.getUrl().getPort() : null),

--- a/src/main/resources/schema/cc-index-schema-flat.json
+++ b/src/main/resources/schema/cc-index-schema-flat.json
@@ -110,6 +110,15 @@
       }
     },
     {
+      "name": "url_host_name_reversed",
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Hostname, excluding IP addresses, in reverse domain name notation",
+        "example": "com.example.www"
+      }
+    },
+    {
       "name": "url_protocol",
       "type": "string",
       "nullable": false,

--- a/src/main/resources/schema/cc-index-schema-nested.json
+++ b/src/main/resources/schema/cc-index-schema-nested.json
@@ -123,6 +123,15 @@
                     "description": "Domain name of the host (one level below the private suffix)",
                     "example": "commoncrawl.s3.amazonaws.com or myblog.blogspot.com"
                   }
+                },
+                {
+                  "name": "name_reversed",
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Hostname, excluding IP addresses, in reverse domain name notation",
+                    "example": "com.example.www"
+                  }
                 }
               ]
             }

--- a/src/sql/athena/cc-index-create-table-flat.sql
+++ b/src/sql/athena/cc-index-create-table-flat.sql
@@ -18,6 +18,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS ccindex (
   url_host_registered_domain    STRING,
   url_host_private_suffix       STRING,
   url_host_private_domain       STRING,
+  url_host_name_reversed        STRING,
   url_protocol                  STRING,
   url_port                      INT,
   url_path                      STRING,

--- a/src/sql/athena/cc-index-create-table-nested.sql
+++ b/src/sql/athena/cc-index-create-table-nested.sql
@@ -6,7 +6,7 @@
 --  * s3:// path (LOCATION)
 --
 CREATE EXTERNAL TABLE IF NOT EXISTS ccindex (
-  url     STRUCT<surtkey:STRING, url:STRING, host:STRUCT<name:STRING, tld:STRING, 2nd_last_part:STRING, 3rd_last_part:STRING, 4th_last_part:STRING, 5th_last_part:STRING, registry_suffix:STRING, registered_domain:STRING, private_suffix:STRING, private_domain:STRING>, protocol:STRING, port:INT, path:STRING, query:STRING>,
+  url     STRUCT<surtkey:STRING, url:STRING, host:STRUCT<name:STRING, tld:STRING, 2nd_last_part:STRING, 3rd_last_part:STRING, 4th_last_part:STRING, 5th_last_part:STRING, registry_suffix:STRING, registered_domain:STRING, private_suffix:STRING, private_domain:STRING, name_reversed:STRING>, protocol:STRING, port:INT, path:STRING, query:STRING>,
   fetch   STRUCT<time:TIMESTAMP, status:SMALLINT, redirect:STRING>,
   content STRUCT<digest:STRING, mime_type:STRING, mime_detected:STRING, charset:STRING, languages:STRING, truncated:STRING>,
   warc    STRUCT<filename:STRING, record_offset:INT, record_length:INT, segment:STRING>)

--- a/src/test/java/org/commoncrawl/net/TestURL.java
+++ b/src/test/java/org/commoncrawl/net/TestURL.java
@@ -79,4 +79,10 @@ public class TestURL {
 		assertEquals("myblog.blogspot.com", h.getPrivateDomainName());
 		assertEquals("blogspot.com", h.getDomainNameUnderRegistrySuffix());
 	}
+
+	@Test
+	void testHostNameReversed() {
+		HostName h = new HostName(getHostName(exampleUrl));
+		assertEquals("com.example.www", h.getHostNameReversed());
+	}
 }

--- a/src/test/java/org/commoncrawl/spark/TestCCIndex2Table.java
+++ b/src/test/java/org/commoncrawl/spark/TestCCIndex2Table.java
@@ -29,8 +29,6 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
-import org.commoncrawl.spark.CCIndex2Table;
-
 
 public class TestCCIndex2Table {
 


### PR DESCRIPTION
Add column `url_host_name_reversed` - host name in [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) (`com.example.www`).
- except for IP addresses the reversed host name column holds the same information as the host name column
- for IP addresses the value is `null`

Objectives:
- because the column values are sorted globally by SURT URL, min/max statistics can be used to significantly reduce the amount of data required to do look ups by host name
  - min/max stats are provided per file (in the Parquet file footer) and per page (in the column index or before Parquet 1.11.0 in the page stats, cf. [PARQUET-1201](https://issues.apache.org/jira/browse/PARQUET-1201))
  - compared to `url_host_name` the min/max intervals should be smaller / more precise
- although the SURT column could also be utilized via a prefix match, the column `url_host_name_reversed` should be significantly smaller in the Parquet file and also more efficient

Thanks to @wumpus and @cldellow for the discussion (a while ago) which led to this improvement.