### PR TITLE
Docker environment to build and run the table converter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.6.3-jdk-11 AS build
+FROM maven:3.9.9-eclipse-temurin-17-focal AS build
 WORKDIR /app
 COPY pom.xml .
 COPY src ./src
 RUN mvn package
 
-FROM spark:3.5.1
+FROM spark:3.5.5-java17-python3
 WORKDIR /app
 COPY --from=build /app/target/*.jar ./target/
 COPY --from=build /app/src/script/convert_url_index.sh ./src/script/convert_url_index.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3.6.3-jdk-11 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn package
+
+FROM spark:3.4.1
+WORKDIR /app
+COPY --from=build /app/target/*.jar ./target/
+COPY --from=build /app/src/script/convert_url_index.sh ./src/script/convert_url_index.sh
+VOLUME /app/data
+ENV SPARK_ON_YARN="--master local"
+ENTRYPOINT ["/app/src/script/convert_url_index.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY pom.xml .
 COPY src ./src
 RUN mvn package
 
-FROM spark:3.4.1
+FROM spark:3.5.1
 WORKDIR /app
 COPY --from=build /app/target/*.jar ./target/
 COPY --from=build /app/src/script/convert_url_index.sh ./src/script/convert_url_index.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ COPY --from=build /app/target/*.jar ./target/
 COPY --from=build /app/src/script/convert_url_index.sh ./src/script/convert_url_index.sh
 VOLUME /app/data
 ENV SPARK_ON_YARN="--master local"
+ENV SPARK_EXTRA_OPTS="--conf spark.executor.userClassPathFirst=true"
 ENTRYPOINT ["/app/src/script/convert_url_index.sh"]


### PR DESCRIPTION
Add a Docker environment to build and run the table converter.

This PR takes the Docker setup out from #32 contributed by @jt55401. It adds a short description about it to the README and upgrades to recent base Docker images. 