### PR TITLE
Add columns to hold WARC-Record-ID and WARC-IP-Address

### DIFF
--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -24,8 +24,8 @@ import org.apache.commons.cli.Options;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.commoncrawl.spark.util.CCWarcFilenameParser;
-import org.commoncrawl.spark.util.CCWarcFilenameParser.FilenameParts;
 import org.commoncrawl.spark.util.CCWarcFilenameParser.FilenameParseError;
+import org.commoncrawl.spark.util.CCWarcFilenameParser.FilenameParts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -17,6 +17,8 @@
 package org.commoncrawl.spark;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -28,6 +30,8 @@ import org.commoncrawl.spark.util.CCWarcFilenameParser.FilenameParseError;
 import org.commoncrawl.spark.util.CCWarcFilenameParser.FilenameParts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.net.InetAddresses;
 
 /**
  * Convert Common Crawl's URL index into a tabular format.
@@ -43,7 +47,7 @@ public class CCIndex2Table extends IndexTable {
 		String redirect;
 		String digest;
 		String mime, mimeDetected;
-		String recordid, ipaddress;
+		byte[] recordid, ipaddress;
 		String filename;
 		int offset, length;
 		short status;
@@ -61,8 +65,19 @@ public class CCIndex2Table extends IndexTable {
 			mime = getString("mime");
 			mimeDetected = getString("mime-detected");
 
-			recordid = getString("recordid");
-			ipaddress = getString("ipaddress");
+			recordid = null;
+			String id = getString("recordid");
+			if (id != null) {
+				UUID uuid = UUID.fromString(id);
+				recordid = new byte[16];
+				ByteBuffer.wrap(recordid)
+						.putLong(uuid.getMostSignificantBits())
+						.putLong(uuid.getLeastSignificantBits());
+			}
+			String ip = getString("ipaddress");
+			if (ip != null) {
+				ipaddress = InetAddresses.forString(ip).getAddress();
+			}
 			filename = getString("filename");
 			offset = getInt("offset");
 			length = getInt("length");

--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -43,6 +43,7 @@ public class CCIndex2Table extends IndexTable {
 		String redirect;
 		String digest;
 		String mime, mimeDetected;
+		String recordid, ipaddress;
 		String filename;
 		int offset, length;
 		short status;
@@ -60,6 +61,8 @@ public class CCIndex2Table extends IndexTable {
 			mime = getString("mime");
 			mimeDetected = getString("mime-detected");
 
+			recordid = getString("recordid");
+			ipaddress = getString("ipaddress");
 			filename = getString("filename");
 			offset = getInt("offset");
 			length = getInt("length");
@@ -102,7 +105,7 @@ public class CCIndex2Table extends IndexTable {
 					RowFactory.create(cdx.timestamp, cdx.status, cdx.redirect), //
 					RowFactory
 							.create(cdx.digest, cdx.mime, cdx.mimeDetected, cdx.charset, cdx.languages, cdx.truncated), //
-					RowFactory.create(cdx.filename, cdx.offset, cdx.length, cdx.segment), //
+					RowFactory.create(cdx.recordid, cdx.ipaddress, cdx.filename, cdx.offset, cdx.length, cdx.segment), //
 					cdx.crawl,
 					cdx.subset);
 		} else {
@@ -142,6 +145,9 @@ public class CCIndex2Table extends IndexTable {
 					cdx.languages,
 					// content (WARC record payload) truncated (since CC-MAIN-2019-47)
 					cdx.truncated,
+					// WARC record headers
+					cdx.recordid,
+					cdx.ipaddress,
 					// WARC record location
 					cdx.filename,
 					cdx.offset,

--- a/src/main/java/org/commoncrawl/spark/util/NullOutputCommitter.java
+++ b/src/main/java/org/commoncrawl/spark/util/NullOutputCommitter.java
@@ -16,11 +16,11 @@
  */
 package org.commoncrawl.spark.util;
 
+import java.io.IOException;
+
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-
-import java.io.IOException;
 
 public class NullOutputCommitter extends OutputCommitter {
 

--- a/src/main/resources/schema/cc-index-schema-flat.json
+++ b/src/main/resources/schema/cc-index-schema-flat.json
@@ -255,7 +255,7 @@
     },
     {
       "name": "warc_record_id",
-      "type": "string",
+      "type": "binary",
       "nullable": true,
       "metadata": {
         "description": "UUID of the WARC record (WARC-Record-ID)",
@@ -266,7 +266,7 @@
     },
     {
       "name": "warc_ip_address",
-      "type": "string",
+      "type": "binary",
       "nullable": true,
       "metadata": {
         "description": "Numeric IP address contacted to retrieve the content (WARC-IP-Address)",

--- a/src/main/resources/schema/cc-index-schema-flat.json
+++ b/src/main/resources/schema/cc-index-schema-flat.json
@@ -254,6 +254,28 @@
       }
     },
     {
+      "name": "warc_record_id",
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "UUID of the WARC record (WARC-Record-ID)",
+        "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d",
+        "since": "CC-MAIN-2026-21",
+        "fromCDX": "recordid"
+      }
+    },
+    {
+      "name": "warc_ip_address",
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "Numeric IP address contacted to retrieve the content (WARC-IP-Address)",
+        "example": "198.202.211.1 or 2620:cb:2000::1",
+        "since": "CC-MAIN-2026-21",
+        "fromCDX": "ipaddress"
+      }
+    },
+    {
       "name": "warc_filename",
       "type": "string",
       "nullable": false,

--- a/src/main/resources/schema/cc-index-schema-nested.json
+++ b/src/main/resources/schema/cc-index-schema-nested.json
@@ -299,6 +299,28 @@
         "type": "struct",
         "fields": [
           {
+            "name": "record_id",
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "UUID of the WARC record (WARC-Record-ID)",
+              "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d",
+              "since": "CC-MAIN-2026-21",
+              "fromCDX": "recordid"
+            }
+          },
+          {
+            "name": "ip_address",
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "Numeric IP address contacted to retrieve the content (WARC-IP-Address)",
+              "example": "198.202.211.1 or 2620:cb:2000::1",
+              "since": "CC-MAIN-2026-21",
+              "fromCDX": "ipaddress"
+            }
+          },
+          {
             "name": "filename",
             "type": "string",
             "nullable": false,

--- a/src/main/resources/schema/cc-index-schema-nested.json
+++ b/src/main/resources/schema/cc-index-schema-nested.json
@@ -300,7 +300,7 @@
         "fields": [
           {
             "name": "record_id",
-            "type": "string",
+            "type": "binary",
             "nullable": true,
             "metadata": {
               "description": "UUID of the WARC record (WARC-Record-ID)",
@@ -311,7 +311,7 @@
           },
           {
             "name": "ip_address",
-            "type": "string",
+            "type": "binary",
             "nullable": true,
             "metadata": {
               "description": "Numeric IP address contacted to retrieve the content (WARC-IP-Address)",

--- a/src/script/convert_url_index.sh
+++ b/src/script/convert_url_index.sh
@@ -55,6 +55,7 @@ $SPARK_HOME/bin/spark-submit \
     --executor-cores $EXECUTOR_CORES \
     --executor-memory $EXECUTOR_MEM \
     --conf spark.hadoop.parquet.enable.dictionary=true \
+    --conf 'spark.hadoop.parquet.enable.dictionary#warc_record_id=false' \
     --conf spark.sql.parquet.filterPushdown=true \
     --conf spark.sql.parquet.mergeSchema=false \
     --conf spark.sql.hive.metastorePartitionPruning=true \


### PR DESCRIPTION
Add two new columns `warc_record_id` and `warc_ip_address` holding the WARC-Record-ID resp. WARC-IP-Address. Both columns use the STRING logical type.

This PR addresses:
- Add IP address column (#30)
- Add WARC-Record-ID column (#42)

