### PR TITLE
Fix URL decoding for robots.txt 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ metastore_db/
 
 # Python
 __pycache__/
+
+# Intellij Idea
+.idea

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -19,6 +19,7 @@ package org.commoncrawl.net;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,22 +41,33 @@ public class WarcUri {
 	public WarcUri(String uriString) {
 		this.uriString = uriString;
 		try {
-			uriString = normalizeMalformedHttpSlashes(uriString);
-
-			try {
-				url = new java.net.URL(uriString);
-				scheme = url.getProtocol();
-				hostName = new HostName(url);
-				uri = url.toURI();
-			} catch (MalformedURLException urlExc) {
-				// should not happen for HTTP captures (how could the URL have been fetched
-				// otherwise) but may happen for other schemes - dns, whois, ntp, metadata
-				uri = new java.net.URI(uriString);
-				scheme = uri.getScheme();
-				hostName = new HostName(uri);
-			}
+			parseAndSetURI(uriString);
 		} catch (URISyntaxException uriExc) {
-			LOG.warn("Failed to parse WARC URI '{}'", this.uriString, uriExc);
+			LOG.warn("Failed to parse WARC URI '{}', trying to normalize slashes", this.uriString, uriExc);
+		}
+
+		if (StringUtils.isBlank(getHostName().getHostName())) {
+			uriString = normalizeMalformedHttpSlashes(uriString);
+			try {
+				parseAndSetURI(uriString);
+			} catch (URISyntaxException e) {
+				LOG.warn("Failed to parse WARC URI '{}' after normalizing slashes", this.uriString, e);
+			}
+		}
+	}
+
+	private void parseAndSetURI(String uriString) throws URISyntaxException {
+		try {
+			this.url = new java.net.URL(uriString);
+			this.scheme = url.getProtocol();
+			this.hostName = new HostName(url);
+			this.uri = url.toURI();
+		} catch (MalformedURLException urlExc) {
+			// should not happen for HTTP captures (how could the URL have been fetched
+			// otherwise) but may happen for other schemes - dns, whois, ntp, metadata
+			this.uri = new java.net.URI(uriString);
+			this.scheme = uri.getScheme();
+			this.hostName = new HostName(uri);
 		}
 	}
 

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -40,7 +40,8 @@ public class WarcUri {
 	public WarcUri(String uriString) {
 		this.uriString = uriString;
 		try {
-			//LF: hot fix to work around malformed robot.txt urls such as https:////sites.google.com/robots.txt
+			// LF: hot fix to work around malformed robot.txt urls such as
+			// https:////sites.google.com/robots.txt
 			uriString = uriString.replaceFirst("^(https?:)/{2,}", "$1//");
 
 			try {

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -19,12 +19,17 @@ package org.commoncrawl.net;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Parses a string representation of a URI or URL found as WARC-Target-URI and
  * provides access to the parts of the URL/URI. Cf. {@link java.net.URL},
  * {@link java.net.URI} and {@link HostName}.
  */
 public class WarcUri {
+
+	private static final Logger LOG = LoggerFactory.getLogger(WarcUri.class);
 
 	private String uriString;
 	private java.net.URL url;
@@ -51,7 +56,7 @@ public class WarcUri {
 				hostName = new HostName(uri);
 			}
 		} catch (URISyntaxException uriExc) {
-			// failed to be parsed into parts
+			LOG.warn("Failed to parse WARC URI '{}': {}", this.uriString, uriExc);
 		}
 	}
 

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -19,7 +19,6 @@ package org.commoncrawl.net;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +45,7 @@ public class WarcUri {
 			LOG.warn("Failed to parse WARC URI '{}', trying to normalize slashes", this.uriString, uriExc);
 		}
 
-		if (StringUtils.isBlank(getHostName().getHostName())) {
+		if (this.hostName == null || this.hostName.getHostName().isEmpty()) {
 			uriString = normalizeMalformedHttpSlashes(uriString);
 			try {
 				parseAndSetURI(uriString);

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -35,6 +35,9 @@ public class WarcUri {
 	public WarcUri(String uriString) {
 		this.uriString = uriString;
 		try {
+			//LF: hot fix to work around malformed robot.txt urls such as https:////sites.google.com/robots.txt
+			uriString = uriString.replaceFirst("^(https?:)/{2,}", "$1//");
+
 			try {
 				url = new java.net.URL(uriString);
 				scheme = url.getProtocol();

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -45,7 +45,7 @@ public class WarcUri {
 			LOG.warn("Failed to parse WARC URI '{}', trying to normalize slashes", this.uriString, uriExc);
 		}
 
-		if (this.hostName == null || this.hostName.getHostName().isEmpty()) {
+		if (this.hostName == null || (this.hostName.getHostName() != null && this.hostName.getHostName().isEmpty())) {
 			uriString = normalizeMalformedHttpSlashes(uriString);
 			try {
 				parseAndSetURI(uriString);

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -40,9 +40,7 @@ public class WarcUri {
 	public WarcUri(String uriString) {
 		this.uriString = uriString;
 		try {
-			// LF: hot fix to work around malformed robot.txt urls such as
-			// https:////sites.google.com/robots.txt
-			uriString = uriString.replaceFirst("^(https?:)/{2,}", "$1//");
+			uriString = normalizeMalformedHttpSlashes(uriString);
 
 			try {
 				url = new java.net.URL(uriString);
@@ -59,6 +57,26 @@ public class WarcUri {
 		} catch (URISyntaxException uriExc) {
 			LOG.warn("Failed to parse WARC URI '{}'", this.uriString, uriExc);
 		}
+	}
+
+	private static String normalizeMalformedHttpSlashes(String uriString) {
+		String schemePrefix;
+		if (uriString.startsWith("http:")) {
+			schemePrefix = "http:";
+		} else if (uriString.startsWith("https:")) {
+			schemePrefix = "https:";
+		} else {
+			return uriString;
+		}
+		int slashStart = schemePrefix.length();
+		int slashEnd = slashStart;
+		while (slashEnd < uriString.length() && uriString.charAt(slashEnd) == '/') {
+			slashEnd++;
+		}
+		if (slashEnd - slashStart < 3) {
+			return uriString;
+		}
+		return schemePrefix + "//" + uriString.substring(slashEnd);
 	}
 
 	public String getScheme() {

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -56,7 +56,7 @@ public class WarcUri {
 				hostName = new HostName(uri);
 			}
 		} catch (URISyntaxException uriExc) {
-			LOG.warn("Failed to parse WARC URI '{}': {}", this.uriString, uriExc);
+			LOG.warn("Failed to parse WARC URI '{}'", this.uriString, uriExc);
 		}
 	}
 

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -84,7 +84,7 @@ public class WarcUri {
 		while (slashEnd < uriString.length() && uriString.charAt(slashEnd) == '/') {
 			slashEnd++;
 		}
-		if (slashEnd - slashStart < 3) {
+		if (slashEnd - slashStart == 2) {
 			return uriString;
 		}
 		return schemePrefix + "//" + uriString.substring(slashEnd);

--- a/src/main/java/org/commoncrawl/net/WarcUri.java
+++ b/src/main/java/org/commoncrawl/net/WarcUri.java
@@ -70,7 +70,7 @@ public class WarcUri {
 		}
 	}
 
-	private static String normalizeMalformedHttpSlashes(String uriString) {
+	static String normalizeMalformedHttpSlashes(String uriString) {
 		String schemePrefix;
 		if (uriString.startsWith("http:")) {
 			schemePrefix = "http:";

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -1,0 +1,24 @@
+package org.commoncrawl.net;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WarcUriTest {
+
+    @Test
+    void getHostName_malformedHttps_shouldNotBeEmpty(){
+        WarcUri warcUri = new WarcUri("https:////www.google.com/robot.txt");
+        assertNotNull(warcUri.getHostName());
+        assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
+    }
+
+    @Test
+    void getHostName_malformedHttp_shouldNotBeEmpty(){
+        WarcUri warcUri = new WarcUri("http:////www.google.com/robot.txt");
+        assertNotNull(warcUri.getHostName());
+        assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
+    }
+}

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -26,8 +26,6 @@ class WarcUriTest {
 	@Test
 	void getHostNameWithMalformedHttpsShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("https:////www.google.com/robots.txt");
-		assertNotNull(warcUri.getHostName());
-		assertNotEquals("", warcUri.getHostName().getHostName(), "getHostName() should not return an empty string.");
 		assertEquals(
 				"www.google.com",
 				warcUri.getHostName().getHostName(),
@@ -37,8 +35,6 @@ class WarcUriTest {
 	@Test
 	void getHostNameMalformedHttpShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("http:////www.google.com/robots.txt");
-		assertNotNull(warcUri.getHostName());
-		assertNotEquals("", warcUri.getHostName().getHostName(), "getHostName() should not return an empty string.");
 		assertEquals(
 				"www.google.com",
 				warcUri.getHostName().getHostName(),
@@ -48,8 +44,6 @@ class WarcUriTest {
 	@Test
 	void getHostNameValidHttpHostShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("http://sites.google.com////robots.txt");
-		assertNotNull(warcUri.getHostName());
-		assertNotEquals("", warcUri.getHostName().getHostName(), "getHostName() should not return an empty string.");
 		assertEquals(
 				"sites.google.com",
 				warcUri.getHostName().getHostName(),
@@ -59,8 +53,6 @@ class WarcUriTest {
 	@Test
 	void getHostNameValidHttpsHostShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("https://sites.google.com////robots.txt");
-		assertNotNull(warcUri.getHostName());
-		assertNotEquals("", warcUri.getHostName().getHostName(), "getHostName() should not return an empty string.");
 		assertEquals(
 				"sites.google.com",
 				warcUri.getHostName().getHostName(),

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.commoncrawl.net;
 
 import org.apache.commons.lang3.StringUtils;

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -17,12 +17,9 @@
 
 package org.commoncrawl.net;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WarcUriTest {
 
@@ -30,9 +27,7 @@ class WarcUriTest {
 	void getHostNameWithMalformedHttpsShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("https:////www.google.com/robots.txt");
 		assertNotNull(warcUri.getHostName());
-		assertTrue(
-				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
-				"getHostName() should not return an empty string.");
+		assertNotEquals("", warcUri.getHostName().getHostName(), "getHostName() should not return an empty string.");
 		assertEquals(
 				"www.google.com",
 				warcUri.getHostName().getHostName(),
@@ -43,9 +38,7 @@ class WarcUriTest {
 	void getHostNameMalformedHttpShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("http:////www.google.com/robots.txt");
 		assertNotNull(warcUri.getHostName());
-		assertTrue(
-				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
-				"getHostName() should not return an empty string.");
+		assertNotEquals("", warcUri.getHostName().getHostName(), "getHostName() should not return an empty string.");
 		assertEquals(
 				"www.google.com",
 				warcUri.getHostName().getHostName(),
@@ -56,9 +49,7 @@ class WarcUriTest {
 	void getHostNameValidHttpHostShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("http://sites.google.com////robots.txt");
 		assertNotNull(warcUri.getHostName());
-		assertTrue(
-				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
-				"getHostName() should not return an empty string.");
+		assertNotEquals("", warcUri.getHostName().getHostName(), "getHostName() should not return an empty string.");
 		assertEquals(
 				"sites.google.com",
 				warcUri.getHostName().getHostName(),
@@ -69,9 +60,7 @@ class WarcUriTest {
 	void getHostNameValidHttpsHostShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("https://sites.google.com////robots.txt");
 		assertNotNull(warcUri.getHostName());
-		assertTrue(
-				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
-				"getHostName() should not return an empty string.");
+		assertNotEquals("", warcUri.getHostName().getHostName(), "getHostName() should not return an empty string.");
 		assertEquals(
 				"sites.google.com",
 				warcUri.getHostName().getHostName(),

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -3,8 +3,7 @@ package org.commoncrawl.net;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WarcUriTest {
 
@@ -13,6 +12,7 @@ class WarcUriTest {
         WarcUri warcUri = new WarcUri("https:////www.google.com/robot.txt");
         assertNotNull(warcUri.getHostName());
         assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
+        assertEquals("www.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'www.google.com' for the malformed URL.");
     }
 
     @Test
@@ -20,5 +20,22 @@ class WarcUriTest {
         WarcUri warcUri = new WarcUri("http:////www.google.com/robot.txt");
         assertNotNull(warcUri.getHostName());
         assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
+        assertEquals("www.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'www.google.com' for the malformed URL.");
+    }
+
+    @Test
+    void getHostName_validHttpHost_shouldNotBeEmpty(){
+        WarcUri warcUri = new WarcUri("http://sites.google.com////robot.txt");
+        assertNotNull(warcUri.getHostName());
+        assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
+        assertEquals("sites.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'www.google.com' for the malformed URL.");
+    }
+
+    @Test
+    void getHostName_validHttpsHost_shouldNotBeEmpty(){
+        WarcUri warcUri = new WarcUri("https://sites.google.com////robot.txt");
+        assertNotNull(warcUri.getHostName());
+        assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
+        assertEquals("sites.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'www.google.com' for the malformed URL.");
     }
 }

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class WarcUriTest {
 
 	@Test
-	void getHostName_malformedHttps_shouldNotBeEmpty() {
+	void getHostNameWithMalformedHttpsShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("https:////www.google.com/robots.txt");
 		assertNotNull(warcUri.getHostName());
 		assertTrue(
@@ -40,7 +40,7 @@ class WarcUriTest {
 	}
 
 	@Test
-	void getHostName_malformedHttp_shouldNotBeEmpty() {
+	void getHostNameMalformedHttpShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("http:////www.google.com/robots.txt");
 		assertNotNull(warcUri.getHostName());
 		assertTrue(
@@ -53,7 +53,7 @@ class WarcUriTest {
 	}
 
 	@Test
-	void getHostName_validHttpHost_shouldNotBeEmpty() {
+	void getHostNameValidHttpHostShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("http://sites.google.com////robots.txt");
 		assertNotNull(warcUri.getHostName());
 		assertTrue(
@@ -66,7 +66,7 @@ class WarcUriTest {
 	}
 
 	@Test
-	void getHostName_validHttpsHost_shouldNotBeEmpty() {
+	void getHostNameValidHttpsHostShouldNotBeEmpty() {
 		WarcUri warcUri = new WarcUri("https://sites.google.com////robots.txt");
 		assertNotNull(warcUri.getHostName());
 		assertTrue(

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -66,4 +66,50 @@ class WarcUriTest {
 				warcUri.getHostName().getHostName(),
 				"getHostName() should return 'sites.google.com' for the URL with extra path slashes.");
 	}
+
+	@Test
+	void testNormalizeMalformedHttpUrlOK() {
+
+		String url = "http://www.google.com/robots.txt";
+
+		assertEquals(
+				url,
+				WarcUri.normalizeMalformedHttpSlashes(url),
+				"Normalizer should not change a well-formed URL.");
+	}
+
+	@Test
+	void testNormalizeMalformedHttpsUrlOK() {
+
+		String url = "https://www.google.com/robots.txt";
+
+		assertEquals(
+				url,
+				WarcUri.normalizeMalformedHttpSlashes(url),
+				"Normalizer should not change a well-formed URL.");
+	}
+
+	@Test
+	void testNormalizeMalformedHttps3SlashesIsFixed() {
+		assertEquals(
+				"http://www.google.com/robots.txt",
+				WarcUri.normalizeMalformedHttpSlashes("http:///www.google.com/robots.txt"),
+				"Normalizer should fix change a malformed URL with three slashes.");
+	}
+
+	@Test
+	void testNormalizeMalformedHttps4SlashesIsFixed() {
+		assertEquals(
+				"http://www.google.com/robots.txt",
+				WarcUri.normalizeMalformedHttpSlashes("http:////www.google.com/robots.txt"),
+				"Normalizer should fix change a malformed URL with four slashes.");
+	}
+
+	@Test
+	void testNormalizeMalformedHttps1SlashIsFixed() {
+		assertEquals(
+				"http://www.google.com/robots.txt",
+				WarcUri.normalizeMalformedHttpSlashes("http:/www.google.com/robots.txt"),
+				"Normalizer should fix change a malformed URL with one slash.");
+	}
 }

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -28,7 +28,7 @@ class WarcUriTest {
         WarcUri warcUri = new WarcUri("http://sites.google.com////robot.txt");
         assertNotNull(warcUri.getHostName());
         assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
-        assertEquals("sites.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'www.google.com' for the malformed URL.");
+        assertEquals("sites.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'sites.google.com' for the URL with extra path slashes.");
     }
 
     @Test
@@ -36,6 +36,6 @@ class WarcUriTest {
         WarcUri warcUri = new WarcUri("https://sites.google.com////robot.txt");
         assertNotNull(warcUri.getHostName());
         assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
-        assertEquals("sites.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'www.google.com' for the malformed URL.");
+        assertEquals("sites.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'sites.google.com' for the URL with extra path slashes.");
     }
 }

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -112,4 +112,12 @@ class WarcUriTest {
 				WarcUri.normalizeMalformedHttpSlashes("http:/www.google.com/robots.txt"),
 				"Normalizer should fix change a malformed URL with one slash.");
 	}
+
+	@Test
+	void testNormalizeMalformedFtpShouldIgnore() {
+		assertEquals(
+				"ftp://////ftp.google.com",
+				WarcUri.normalizeMalformedHttpSlashes("ftp://////ftp.google.com"),
+				"Normalizer should fix change a malformed URL with one slash.");
+	}
 }

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -7,35 +7,55 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class WarcUriTest {
 
-    @Test
-    void getHostName_malformedHttps_shouldNotBeEmpty(){
-        WarcUri warcUri = new WarcUri("https:////www.google.com/robot.txt");
-        assertNotNull(warcUri.getHostName());
-        assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
-        assertEquals("www.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'www.google.com' for the malformed URL.");
-    }
+	@Test
+	void getHostName_malformedHttps_shouldNotBeEmpty() {
+		WarcUri warcUri = new WarcUri("https:////www.google.com/robot.txt");
+		assertNotNull(warcUri.getHostName());
+		assertTrue(
+				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
+				"getHostName() should not return an empty string.");
+		assertEquals(
+				"www.google.com",
+				warcUri.getHostName().getHostName(),
+				"getHostName() should return 'www.google.com' for the malformed URL.");
+	}
 
-    @Test
-    void getHostName_malformedHttp_shouldNotBeEmpty(){
-        WarcUri warcUri = new WarcUri("http:////www.google.com/robot.txt");
-        assertNotNull(warcUri.getHostName());
-        assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
-        assertEquals("www.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'www.google.com' for the malformed URL.");
-    }
+	@Test
+	void getHostName_malformedHttp_shouldNotBeEmpty() {
+		WarcUri warcUri = new WarcUri("http:////www.google.com/robot.txt");
+		assertNotNull(warcUri.getHostName());
+		assertTrue(
+				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
+				"getHostName() should not return an empty string.");
+		assertEquals(
+				"www.google.com",
+				warcUri.getHostName().getHostName(),
+				"getHostName() should return 'www.google.com' for the malformed URL.");
+	}
 
-    @Test
-    void getHostName_validHttpHost_shouldNotBeEmpty(){
-        WarcUri warcUri = new WarcUri("http://sites.google.com////robot.txt");
-        assertNotNull(warcUri.getHostName());
-        assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
-        assertEquals("sites.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'sites.google.com' for the URL with extra path slashes.");
-    }
+	@Test
+	void getHostName_validHttpHost_shouldNotBeEmpty() {
+		WarcUri warcUri = new WarcUri("http://sites.google.com////robot.txt");
+		assertNotNull(warcUri.getHostName());
+		assertTrue(
+				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
+				"getHostName() should not return an empty string.");
+		assertEquals(
+				"sites.google.com",
+				warcUri.getHostName().getHostName(),
+				"getHostName() should return 'sites.google.com' for the URL with extra path slashes.");
+	}
 
-    @Test
-    void getHostName_validHttpsHost_shouldNotBeEmpty(){
-        WarcUri warcUri = new WarcUri("https://sites.google.com////robot.txt");
-        assertNotNull(warcUri.getHostName());
-        assertTrue(StringUtils.isNotEmpty(warcUri.getHostName().getHostName()), "getHostName() should not return an empty string.");
-        assertEquals("sites.google.com", warcUri.getHostName().getHostName(), "getHostName() should return 'sites.google.com' for the URL with extra path slashes.");
-    }
+	@Test
+	void getHostName_validHttpsHost_shouldNotBeEmpty() {
+		WarcUri warcUri = new WarcUri("https://sites.google.com////robot.txt");
+		assertNotNull(warcUri.getHostName());
+		assertTrue(
+				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
+				"getHostName() should not return an empty string.");
+		assertEquals(
+				"sites.google.com",
+				warcUri.getHostName().getHostName(),
+				"getHostName() should return 'sites.google.com' for the URL with extra path slashes.");
+	}
 }

--- a/src/test/java/org/commoncrawl/net/WarcUriTest.java
+++ b/src/test/java/org/commoncrawl/net/WarcUriTest.java
@@ -3,13 +3,15 @@ package org.commoncrawl.net;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class WarcUriTest {
 
 	@Test
 	void getHostName_malformedHttps_shouldNotBeEmpty() {
-		WarcUri warcUri = new WarcUri("https:////www.google.com/robot.txt");
+		WarcUri warcUri = new WarcUri("https:////www.google.com/robots.txt");
 		assertNotNull(warcUri.getHostName());
 		assertTrue(
 				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
@@ -22,7 +24,7 @@ class WarcUriTest {
 
 	@Test
 	void getHostName_malformedHttp_shouldNotBeEmpty() {
-		WarcUri warcUri = new WarcUri("http:////www.google.com/robot.txt");
+		WarcUri warcUri = new WarcUri("http:////www.google.com/robots.txt");
 		assertNotNull(warcUri.getHostName());
 		assertTrue(
 				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
@@ -35,7 +37,7 @@ class WarcUriTest {
 
 	@Test
 	void getHostName_validHttpHost_shouldNotBeEmpty() {
-		WarcUri warcUri = new WarcUri("http://sites.google.com////robot.txt");
+		WarcUri warcUri = new WarcUri("http://sites.google.com////robots.txt");
 		assertNotNull(warcUri.getHostName());
 		assertTrue(
 				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),
@@ -48,7 +50,7 @@ class WarcUriTest {
 
 	@Test
 	void getHostName_validHttpsHost_shouldNotBeEmpty() {
-		WarcUri warcUri = new WarcUri("https://sites.google.com////robot.txt");
+		WarcUri warcUri = new WarcUri("https://sites.google.com////robots.txt");
 		assertNotNull(warcUri.getHostName());
 		assertTrue(
 				StringUtils.isNotEmpty(warcUri.getHostName().getHostName()),


### PR DESCRIPTION
This PR addresses the problem found in the April Crawl for processing `robots.txt` URLs that resulted in an empty/null hostname.

Background information: The target URLs of robots.txt redirects are not passed to URL filters before the redirects are followed. RFC 9309 just specifies to follow five levels of redirect and does not require or even recommend normalization of redirect targets. As a consequence, the robots.txt URLs stemming from redirects may have an unexpected form. 