### PR TITLE
Fix host decoding with punycodes in URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ metastore_db/
 
 # Python
 __pycache__/
+.idea

--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -16,7 +16,6 @@
  */
 package org.commoncrawl.net;
 
-import java.io.UnsupportedEncodingException;
 import java.net.IDN;
 import java.net.InetAddress;
 import java.net.URI;
@@ -36,6 +35,10 @@ import com.google.common.base.CharMatcher;
 
 import crawlercommons.domains.EffectiveTldFinder;
 import crawlercommons.domains.EffectiveTldFinder.EffectiveTLD;
+
+import static crawlercommons.domains.EffectiveTldFinder.DOT_REGEX;
+import static java.net.IDN.ALLOW_UNASSIGNED;
+import static org.apache.commons.lang3.StringUtils.join;
 
 public class HostName {
 
@@ -114,6 +117,32 @@ public class HostName {
 		}
 	}
 
+	static String asciiConvert(String str) throws IllegalArgumentException {
+		if (isAscii(str)) {
+			return str.toLowerCase(Locale.ROOT);
+		}
+		return IDN.toASCII(str, ALLOW_UNASSIGNED);
+	}
+
+	static boolean isAscii(String str) {
+		char[] chars = str.toCharArray();
+		for (char c : chars) {
+			if (c > 127) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	static String normalizeName(String name) throws IllegalArgumentException {
+		String[] parts = name.split(DOT_REGEX);
+		String[] ary = new String[parts.length];
+		for (int i = 0; i < parts.length; i++) {
+			ary[i] = asciiConvert(parts[i]);
+		}
+		return join(ary, ".");
+	}
+
 	private void setHostName(String name) {
 		hostName = name;
 		if (IPV4_ADDRESS_PATTERN_CANONICAL.matcher(hostName).matches()) {
@@ -132,20 +161,31 @@ public class HostName {
 			type = Type.hostname;
 			if (hostName.indexOf('%') > -1) {
 				try {
-					hostName = URLDecoder.decode(hostName, StandardCharsets.UTF_8.toString());
-				} catch (IllegalArgumentException | UnsupportedEncodingException e) {
-					LOG.error("Failed to decode {}: {}", hostName, e, e.getMessage());
-					hostName = null;
-					return;
+					hostName = URLDecoder.decode(hostName, StandardCharsets.UTF_8);
+				} catch (IllegalArgumentException e) {
+					// LF not sure that we need this, added as defensive measure against another failure
+					try {
+						hostName = normalizeName(hostName);
+					} catch (IllegalArgumentException e2) {
+						e.addSuppressed(e2);
+						LOG.error("Failed to decode {}: {}", hostName, e.getMessage(), e);
+						hostName = null;
+						return;
+					}
 				}
 			}
 			if (!CharMatcher.ascii().matchesAllOf(hostName)) {
 				try {
 					hostName = IDN.toASCII(hostName);
 				} catch (IllegalArgumentException | IndexOutOfBoundsException e) {
-					LOG.error("Failed to convert Unicode host name to ASCII {}: {}", hostName, e, e.getMessage());
-					hostName = null;
-					return;
+					try {
+						hostName = normalizeName(hostName);
+					} catch (IllegalArgumentException e2) {
+						e.addSuppressed(e2);
+						LOG.error("Failed to convert Unicode host name to ASCII {}: {}", hostName, e.getMessage(), e);
+						hostName = null;
+						return;
+					}
 				}
 			}
 			if (hostName.endsWith(".")) {
@@ -213,7 +253,7 @@ public class HostName {
 	/**
 	 * Split host name into parts in reverse order: <code>www.example.com</code>
 	 * becomes <code>[com, example, www]</code>.
-	 * 
+	 *
 	 * @param hostName host name, e.g. <code>www.example.com</code>
 	 * @return parts of host name in reverse order
 	 */
@@ -230,7 +270,7 @@ public class HostName {
 	/**
 	 * Canonicalize IP address strings which are accepted by
 	 * {@link InetAddress#getByName(String)}.
-	 * 
+	 *
 	 * @param ipAddrStr string representing a <strong>valid</strong> IP address
 	 * @return the canonical representation of the IP address
 	 */
@@ -262,7 +302,7 @@ public class HostName {
 	 * Reverse host is null if the host name is an IP address. Domain name and
 	 * suffixes are null if the host name is an IP address, or if no valid suffix is
 	 * found.
-	 * 
+	 *
 	 * @return row
 	 */
 	public Row asRow() {

--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -36,7 +36,6 @@ import com.google.common.base.CharMatcher;
 import crawlercommons.domains.EffectiveTldFinder;
 import crawlercommons.domains.EffectiveTldFinder.EffectiveTLD;
 
-import static crawlercommons.domains.EffectiveTldFinder.DOT_REGEX;
 import static java.net.IDN.ALLOW_UNASSIGNED;
 
 public class HostName {
@@ -116,32 +115,6 @@ public class HostName {
 		}
 	}
 
-	static String asciiConvert(String str) throws IllegalArgumentException {
-		if (isAscii(str)) {
-			return str.toLowerCase(Locale.ROOT);
-		}
-		return IDN.toASCII(str, ALLOW_UNASSIGNED);
-	}
-
-	static boolean isAscii(String str) {
-		char[] chars = str.toCharArray();
-		for (char c : chars) {
-			if (c > 127) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	static String normalizeName(String name) throws IllegalArgumentException {
-		String[] parts = name.split(DOT_REGEX);
-		String[] ary = new String[parts.length];
-		for (int i = 0; i < parts.length; i++) {
-			ary[i] = asciiConvert(parts[i]);
-		}
-		return String.join(".", ary);
-	}
-
 	private void setHostName(String name) {
 		hostName = name;
 		if (IPV4_ADDRESS_PATTERN_CANONICAL.matcher(hostName).matches()) {
@@ -162,23 +135,16 @@ public class HostName {
 				try {
 					hostName = URLDecoder.decode(hostName, StandardCharsets.UTF_8);
 				} catch (IllegalArgumentException e) {
-					try {
-						hostName = normalizeName(hostName);
-					} catch (IllegalArgumentException | IndexOutOfBoundsException e2) {
-						e.addSuppressed(e2);
-						LOG.error("Failed to decode {}: {}", hostName, e.getMessage(), e);
-						hostName = null;
-						return;
-					}
+					LOG.error("Failed to decode {}: {}", hostName, e.getMessage(), e);
 				}
 			}
 			if (!CharMatcher.ascii().matchesAllOf(hostName)) {
 				try {
 					hostName = IDN.toASCII(hostName);
-				} catch (IllegalArgumentException | IndexOutOfBoundsException e) {
+				} catch (IllegalArgumentException e) {
 					try {
-						hostName = normalizeName(hostName);
-					} catch (IllegalArgumentException | IndexOutOfBoundsException e2) {
+						hostName = IDN.toASCII(hostName, ALLOW_UNASSIGNED);
+					} catch (IllegalArgumentException e2) {
 						e.addSuppressed(e2);
 						LOG.error("Failed to convert Unicode host name to ASCII {}: {}", hostName, e.getMessage(), e);
 						hostName = null;

--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -16,6 +16,7 @@
  */
 package org.commoncrawl.net;
 
+import java.io.UnsupportedEncodingException;
 import java.net.IDN;
 import java.net.InetAddress;
 import java.net.URI;
@@ -141,10 +142,10 @@ public class HostName {
 			if (!CharMatcher.ascii().matchesAllOf(hostName)) {
 				try {
 					hostName = IDN.toASCII(hostName);
-				} catch (IllegalArgumentException e) {
+				} catch (IllegalArgumentException | IndexOutOfBoundsException e) {
 					try {
 						hostName = IDN.toASCII(hostName, ALLOW_UNASSIGNED);
-					} catch (IllegalArgumentException e2) {
+					} catch (IllegalArgumentException | IndexOutOfBoundsException e2) {
 						e.addSuppressed(e2);
 						LOG.error("Failed to convert Unicode host name to ASCII {}: {}", hostName, e.getMessage(), e);
 						hostName = null;

--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -38,7 +38,6 @@ import crawlercommons.domains.EffectiveTldFinder.EffectiveTLD;
 
 import static crawlercommons.domains.EffectiveTldFinder.DOT_REGEX;
 import static java.net.IDN.ALLOW_UNASSIGNED;
-import static org.apache.commons.lang3.StringUtils.join;
 
 public class HostName {
 
@@ -140,7 +139,7 @@ public class HostName {
 		for (int i = 0; i < parts.length; i++) {
 			ary[i] = asciiConvert(parts[i]);
 		}
-		return join(ary, ".");
+		return String.join(".", ary);
 	}
 
 	private void setHostName(String name) {
@@ -163,11 +162,9 @@ public class HostName {
 				try {
 					hostName = URLDecoder.decode(hostName, StandardCharsets.UTF_8);
 				} catch (IllegalArgumentException e) {
-					// LF not sure that we need this, added as defensive measure against another
-					// failure
 					try {
 						hostName = normalizeName(hostName);
-					} catch (IllegalArgumentException e2) {
+					} catch (IllegalArgumentException | IndexOutOfBoundsException e2) {
 						e.addSuppressed(e2);
 						LOG.error("Failed to decode {}: {}", hostName, e.getMessage(), e);
 						hostName = null;

--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -141,16 +141,11 @@ public class HostName {
 			}
 			if (!CharMatcher.ascii().matchesAllOf(hostName)) {
 				try {
-					hostName = IDN.toASCII(hostName);
+					hostName = IDN.toASCII(hostName, ALLOW_UNASSIGNED);
 				} catch (IllegalArgumentException | IndexOutOfBoundsException e) {
-					try {
-						hostName = IDN.toASCII(hostName, ALLOW_UNASSIGNED);
-					} catch (IllegalArgumentException | IndexOutOfBoundsException e2) {
-						e.addSuppressed(e2);
-						LOG.error("Failed to convert Unicode host name to ASCII {}: {}", hostName, e.getMessage(), e);
-						hostName = null;
-						return;
-					}
+					LOG.error("Failed to convert Unicode host name to ASCII {}: {}", hostName, e.getMessage(), e);
+					hostName = null;
+					return;
 				}
 			}
 			if (hostName.endsWith(".")) {

--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -178,7 +178,7 @@ public class HostName {
 				} catch (IllegalArgumentException | IndexOutOfBoundsException e) {
 					try {
 						hostName = normalizeName(hostName);
-					} catch (IllegalArgumentException e2) {
+					} catch (IllegalArgumentException | IndexOutOfBoundsException e2) {
 						e.addSuppressed(e2);
 						LOG.error("Failed to convert Unicode host name to ASCII {}: {}", hostName, e.getMessage(), e);
 						hostName = null;

--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -163,7 +163,8 @@ public class HostName {
 				try {
 					hostName = URLDecoder.decode(hostName, StandardCharsets.UTF_8);
 				} catch (IllegalArgumentException e) {
-					// LF not sure that we need this, added as defensive measure against another failure
+					// LF not sure that we need this, added as defensive measure against another
+					// failure
 					try {
 						hostName = normalizeName(hostName);
 					} catch (IllegalArgumentException e2) {

--- a/src/test/java/org/commoncrawl/net/HostNameTest.java
+++ b/src/test/java/org/commoncrawl/net/HostNameTest.java
@@ -22,9 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class HostNameTest {
-
-	// ── isAscii ────────────────────────────────────────────────────────────────
-
+	
 	@Test
 	void isAscii_shouldReturnTrue() {
 		assertTrue(HostName.isAscii("www.example.com"));
@@ -43,16 +41,14 @@ class HostNameTest {
 	@Test
 	void isAscii_boundaryAscii_returnsTrue() {
 		// DEL = 127 is the last ASCII codepoint
-		assertTrue(HostName.isAscii(""));
+		assertTrue(HostName.isAscii("\u007F"));
 	}
 
 	@Test
 	void isAscii_boundaryNonAscii_returnsFalse() {
 		// 128 is the first non-ASCII codepoint
-		assertFalse(HostName.isAscii(""));
+		assertFalse(HostName.isAscii("\u0080"));
 	}
-
-	// ── normalizeName ──────────────────────────────────────────────────────────
 
 	@Test
 	void normalizeName_punyCode_shouldNormalizeCorrectly() {
@@ -73,8 +69,6 @@ class HostNameTest {
 	void normalizeName_mixedAsciiAndUnicode() {
 		assertEquals("www.xn--qv9h.com", HostName.normalizeName("www.🧠.com"));
 	}
-
-	// ── setHostName end-to-end (regression for url_host_name == null bug) ──────
 
 	@Test
 	void setHostName_brainEmojiPercentEncoded_isPunycoded() {

--- a/src/test/java/org/commoncrawl/net/HostNameTest.java
+++ b/src/test/java/org/commoncrawl/net/HostNameTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.commoncrawl.net;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/commoncrawl/net/HostNameTest.java
+++ b/src/test/java/org/commoncrawl/net/HostNameTest.java
@@ -1,0 +1,89 @@
+package org.commoncrawl.net;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HostNameTest {
+
+    // ── isAscii ────────────────────────────────────────────────────────────────
+
+    @Test
+    void isAscii_shouldReturnTrue() {
+        assertTrue(HostName.isAscii("www.example.com"));
+    }
+
+    @Test
+    void isAscii_shouldReturnFalse() {
+        assertFalse(HostName.isAscii("🧠.s.country"));
+    }
+
+    @Test
+    void isAscii_emptyString_returnsTrue() {
+        assertTrue(HostName.isAscii(""));
+    }
+
+    @Test
+    void isAscii_boundaryAscii_returnsTrue() {
+        // DEL = 127 is the last ASCII codepoint
+        assertTrue(HostName.isAscii(""));
+    }
+
+    @Test
+    void isAscii_boundaryNonAscii_returnsFalse() {
+        // 128 is the first non-ASCII codepoint
+        assertFalse(HostName.isAscii(""));
+    }
+
+    // ── normalizeName ──────────────────────────────────────────────────────────
+
+    @Test
+    void normalizeName_punyCode_shouldNormalizeCorrectly() {
+        assertEquals("xn--qv9h.s.country", HostName.normalizeName("🧠.s.country"));
+    }
+
+    @Test
+    void normalizeName_singleLabel_noDots() {
+        assertEquals("xn--qv9h", HostName.normalizeName("🧠"));
+    }
+
+    @Test
+    void normalizeName_alreadyAscii_lowercased() {
+        assertEquals("www.example.com", HostName.normalizeName("WWW.Example.COM"));
+    }
+
+    @Test
+    void normalizeName_mixedAsciiAndUnicode() {
+        assertEquals("www.xn--qv9h.com", HostName.normalizeName("www.🧠.com"));
+    }
+
+    // ── setHostName end-to-end (regression for url_host_name == null bug) ──────
+
+    @Test
+    void setHostName_brainEmojiPercentEncoded_isPunycoded() {
+        // Mirrors the captured production failure: %f0%9f%a7%a0 = U+1F9E0 (🧠)
+        // Exercises URLDecoder → IDN.toASCII (fails) → normalizeName (recovers).
+        HostName h = new HostName("%f0%9f%a7%a0.s.country");
+        assertEquals("xn--qv9h.s.country", h.getHostName());
+    }
+
+    @Test
+    void setHostName_brainEmojiUnicodeDirect_isPunycoded() {
+        // Skips URLDecoder, exercises only the IDN fallback path.
+        HostName h = new HostName("🧠.s.country");
+        assertEquals("xn--qv9h.s.country", h.getHostName());
+    }
+
+    @Test
+    void setHostName_legitimateIdn_unchanged() {
+        // BMP IDN: strict IDN.toASCII succeeds, fallback is not invoked.
+        HostName h = new HostName("münchen.de");
+        assertEquals("xn--mnchen-3ya.de", h.getHostName());
+    }
+
+    @Test
+    void setHostName_asciiHost_unchanged() {
+        HostName h = new HostName("www.example.com");
+        assertEquals("www.example.com", h.getHostName());
+    }
+}

--- a/src/test/java/org/commoncrawl/net/HostNameTest.java
+++ b/src/test/java/org/commoncrawl/net/HostNameTest.java
@@ -6,84 +6,84 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class HostNameTest {
 
-    // ── isAscii ────────────────────────────────────────────────────────────────
+	// ── isAscii ────────────────────────────────────────────────────────────────
 
-    @Test
-    void isAscii_shouldReturnTrue() {
-        assertTrue(HostName.isAscii("www.example.com"));
-    }
+	@Test
+	void isAscii_shouldReturnTrue() {
+		assertTrue(HostName.isAscii("www.example.com"));
+	}
 
-    @Test
-    void isAscii_shouldReturnFalse() {
-        assertFalse(HostName.isAscii("🧠.s.country"));
-    }
+	@Test
+	void isAscii_shouldReturnFalse() {
+		assertFalse(HostName.isAscii("🧠.s.country"));
+	}
 
-    @Test
-    void isAscii_emptyString_returnsTrue() {
-        assertTrue(HostName.isAscii(""));
-    }
+	@Test
+	void isAscii_emptyString_returnsTrue() {
+		assertTrue(HostName.isAscii(""));
+	}
 
-    @Test
-    void isAscii_boundaryAscii_returnsTrue() {
-        // DEL = 127 is the last ASCII codepoint
-        assertTrue(HostName.isAscii(""));
-    }
+	@Test
+	void isAscii_boundaryAscii_returnsTrue() {
+		// DEL = 127 is the last ASCII codepoint
+		assertTrue(HostName.isAscii(""));
+	}
 
-    @Test
-    void isAscii_boundaryNonAscii_returnsFalse() {
-        // 128 is the first non-ASCII codepoint
-        assertFalse(HostName.isAscii(""));
-    }
+	@Test
+	void isAscii_boundaryNonAscii_returnsFalse() {
+		// 128 is the first non-ASCII codepoint
+		assertFalse(HostName.isAscii(""));
+	}
 
-    // ── normalizeName ──────────────────────────────────────────────────────────
+	// ── normalizeName ──────────────────────────────────────────────────────────
 
-    @Test
-    void normalizeName_punyCode_shouldNormalizeCorrectly() {
-        assertEquals("xn--qv9h.s.country", HostName.normalizeName("🧠.s.country"));
-    }
+	@Test
+	void normalizeName_punyCode_shouldNormalizeCorrectly() {
+		assertEquals("xn--qv9h.s.country", HostName.normalizeName("🧠.s.country"));
+	}
 
-    @Test
-    void normalizeName_singleLabel_noDots() {
-        assertEquals("xn--qv9h", HostName.normalizeName("🧠"));
-    }
+	@Test
+	void normalizeName_singleLabel_noDots() {
+		assertEquals("xn--qv9h", HostName.normalizeName("🧠"));
+	}
 
-    @Test
-    void normalizeName_alreadyAscii_lowercased() {
-        assertEquals("www.example.com", HostName.normalizeName("WWW.Example.COM"));
-    }
+	@Test
+	void normalizeName_alreadyAscii_lowercased() {
+		assertEquals("www.example.com", HostName.normalizeName("WWW.Example.COM"));
+	}
 
-    @Test
-    void normalizeName_mixedAsciiAndUnicode() {
-        assertEquals("www.xn--qv9h.com", HostName.normalizeName("www.🧠.com"));
-    }
+	@Test
+	void normalizeName_mixedAsciiAndUnicode() {
+		assertEquals("www.xn--qv9h.com", HostName.normalizeName("www.🧠.com"));
+	}
 
-    // ── setHostName end-to-end (regression for url_host_name == null bug) ──────
+	// ── setHostName end-to-end (regression for url_host_name == null bug) ──────
 
-    @Test
-    void setHostName_brainEmojiPercentEncoded_isPunycoded() {
-        // Mirrors the captured production failure: %f0%9f%a7%a0 = U+1F9E0 (🧠)
-        // Exercises URLDecoder → IDN.toASCII (fails) → normalizeName (recovers).
-        HostName h = new HostName("%f0%9f%a7%a0.s.country");
-        assertEquals("xn--qv9h.s.country", h.getHostName());
-    }
+	@Test
+	void setHostName_brainEmojiPercentEncoded_isPunycoded() {
+		// Mirrors the captured production failure: %f0%9f%a7%a0 = U+1F9E0 (🧠)
+		// Exercises URLDecoder → IDN.toASCII (fails) → normalizeName (recovers).
+		HostName h = new HostName("%f0%9f%a7%a0.s.country");
+		assertEquals("xn--qv9h.s.country", h.getHostName());
+	}
 
-    @Test
-    void setHostName_brainEmojiUnicodeDirect_isPunycoded() {
-        // Skips URLDecoder, exercises only the IDN fallback path.
-        HostName h = new HostName("🧠.s.country");
-        assertEquals("xn--qv9h.s.country", h.getHostName());
-    }
+	@Test
+	void setHostName_brainEmojiUnicodeDirect_isPunycoded() {
+		// Skips URLDecoder, exercises only the IDN fallback path.
+		HostName h = new HostName("🧠.s.country");
+		assertEquals("xn--qv9h.s.country", h.getHostName());
+	}
 
-    @Test
-    void setHostName_legitimateIdn_unchanged() {
-        // BMP IDN: strict IDN.toASCII succeeds, fallback is not invoked.
-        HostName h = new HostName("münchen.de");
-        assertEquals("xn--mnchen-3ya.de", h.getHostName());
-    }
+	@Test
+	void setHostName_legitimateIdn_unchanged() {
+		// BMP IDN: strict IDN.toASCII succeeds, fallback is not invoked.
+		HostName h = new HostName("münchen.de");
+		assertEquals("xn--mnchen-3ya.de", h.getHostName());
+	}
 
-    @Test
-    void setHostName_asciiHost_unchanged() {
-        HostName h = new HostName("www.example.com");
-        assertEquals("www.example.com", h.getHostName());
-    }
+	@Test
+	void setHostName_asciiHost_unchanged() {
+		HostName h = new HostName("www.example.com");
+		assertEquals("www.example.com", h.getHostName());
+	}
 }

--- a/src/test/java/org/commoncrawl/net/HostNameTest.java
+++ b/src/test/java/org/commoncrawl/net/HostNameTest.java
@@ -22,56 +22,35 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class HostNameTest {
-	
+
 	@Test
-	void isAscii_shouldReturnTrue() {
-		assertTrue(HostName.isAscii("www.example.com"));
+	void normalizeNameBlankInput() {
+		HostName h = new HostName("");
+		assertEquals("", h.getHostName());
 	}
 
 	@Test
-	void isAscii_shouldReturnFalse() {
-		assertFalse(HostName.isAscii("🧠.s.country"));
-	}
-
-	@Test
-	void isAscii_emptyString_returnsTrue() {
-		assertTrue(HostName.isAscii(""));
-	}
-
-	@Test
-	void isAscii_boundaryAscii_returnsTrue() {
+	void normalizeNameAsciiCharInHostName() {
 		// DEL = 127 is the last ASCII codepoint
-		assertTrue(HostName.isAscii("\u007F"));
+
+		HostName h = new HostName("www.\u007F.com");
+		assertEquals("www.\u007F.com", h.getHostName());
+	}
+
+	@Test()
+	void normalizeNameNoAsciiInHostname() {
+		HostName h = new HostName("www.\u0080.com");
+		assertEquals(h.getHostName(), null);
 	}
 
 	@Test
-	void isAscii_boundaryNonAscii_returnsFalse() {
-		// 128 is the first non-ASCII codepoint
-		assertFalse(HostName.isAscii("\u0080"));
+	void normalizeNameMixedPunycodeInHostname() {
+		HostName h = new HostName("www.🧠.com");
+		assertEquals("www.xn--qv9h.com", h.getHostName());
 	}
 
 	@Test
-	void normalizeName_punyCode_shouldNormalizeCorrectly() {
-		assertEquals("xn--qv9h.s.country", HostName.normalizeName("🧠.s.country"));
-	}
-
-	@Test
-	void normalizeName_singleLabel_noDots() {
-		assertEquals("xn--qv9h", HostName.normalizeName("🧠"));
-	}
-
-	@Test
-	void normalizeName_alreadyAscii_lowercased() {
-		assertEquals("www.example.com", HostName.normalizeName("WWW.Example.COM"));
-	}
-
-	@Test
-	void normalizeName_mixedAsciiAndUnicode() {
-		assertEquals("www.xn--qv9h.com", HostName.normalizeName("www.🧠.com"));
-	}
-
-	@Test
-	void setHostName_brainEmojiPercentEncoded_isPunycoded() {
+	void setHostNameBrainEmojiPercentEncoded() {
 		// Mirrors the captured production failure: %f0%9f%a7%a0 = U+1F9E0 (🧠)
 		// Exercises URLDecoder → IDN.toASCII (fails) → normalizeName (recovers).
 		HostName h = new HostName("%f0%9f%a7%a0.s.country");
@@ -79,21 +58,21 @@ class HostNameTest {
 	}
 
 	@Test
-	void setHostName_brainEmojiUnicodeDirect_isPunycoded() {
+	void setHostNameBrainEmojiUnicodeDirect() {
 		// Skips URLDecoder, exercises only the IDN fallback path.
 		HostName h = new HostName("🧠.s.country");
 		assertEquals("xn--qv9h.s.country", h.getHostName());
 	}
 
 	@Test
-	void setHostName_legitimateIdn_unchanged() {
+	void setHostNameLegitimateIdnUnchanged() {
 		// BMP IDN: strict IDN.toASCII succeeds, fallback is not invoked.
 		HostName h = new HostName("münchen.de");
 		assertEquals("xn--mnchen-3ya.de", h.getHostName());
 	}
 
 	@Test
-	void setHostName_asciiHost_unchanged() {
+	void setHostNameAsciiHostUnchanged() {
 		HostName h = new HostName("www.example.com");
 		assertEquals("www.example.com", h.getHostName());
 	}


### PR DESCRIPTION
This PR addresses the issue emerged during the April Crawl where Unicode host names, e.g. `🧠 .s.country` (IDN2008) failed to decode when creating the index table.