### PR TITLE
Patching the WARC filename parser to support additional filename schema

### DIFF
--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -44,7 +44,7 @@ public class CCIndex2Table extends IndexTable {
 		String digest;
 		String mime, mimeDetected;
 		String filename;
-		int offset, length;
+		long offset, length;
 		short status;
 		String crawl, segment, subset;
 		String charset, languages;
@@ -61,8 +61,8 @@ public class CCIndex2Table extends IndexTable {
 			mimeDetected = getString("mime-detected");
 
 			filename = getString("filename");
-			offset = getInt("offset");
-			length = getInt("length");
+			offset = getLong("offset");
+			length = getLong("length");
 			status = getHttpStatus("status");
 
 			try {

--- a/src/main/java/org/commoncrawl/spark/util/CCWarcFilenameParser.java
+++ b/src/main/java/org/commoncrawl/spark/util/CCWarcFilenameParser.java
@@ -30,7 +30,14 @@ public class CCWarcFilenameParser {
 	 */
 	protected static final Pattern filenameAnalyzer = Pattern.compile(
 			"^(?:common-crawl/)?crawl-data/([^/]+)/segments/([^/]+)/(crawldiagnostics|robotstxt|warc|wat|wet)/");
-
+	/**
+	 * Supplemental crawl filename pattern:
+	 * <code>projects/PROJECT/CC-SUPPLEMENTAL-YYYY-WW[-...]/SEGMENT/SUBSET/*.warc.gz</code>
+	 * e.g.
+	 * <code>projects/cc-open-athena-test/CC-SUPPLEMENTAL-2026-22-bis/20260522101936/warc/CC-SUPPLEMENTAL-2026-22-bis-20260522102012-20260522152012-00000.warc.gz</code>
+	 */
+	protected static final Pattern supplementalFilenameAnalyzer = Pattern.compile(
+			"^[^/]+/[^/]+/(CC-SUPPLEMENTAL-[^/]+)/(\\d+)/(crawldiagnostics|robotstxt|warc)/");
 	/**
 	 * News crawl filename pattern:
 	 * <code>s3://commoncrawl/crawl-data/CC-NEWS/YYYY/MM/*.warc.gz</code> e.g.
@@ -64,6 +71,10 @@ public class CCWarcFilenameParser {
 
 	public static FilenameParts getParts(String filename) throws FilenameParseError {
 		Matcher m = filenameAnalyzer.matcher(filename);
+		if (m.find()) {
+			return new FilenameParts(m.group(1), m.group(2), m.group(3));
+		}
+		m = supplementalFilenameAnalyzer.matcher(filename);
 		if (m.find()) {
 			return new FilenameParts(m.group(1), m.group(2), m.group(3));
 		}

--- a/src/main/java/org/commoncrawl/spark/util/CCWarcFilenameParser.java
+++ b/src/main/java/org/commoncrawl/spark/util/CCWarcFilenameParser.java
@@ -37,7 +37,7 @@ public class CCWarcFilenameParser {
 	 * <code>projects/cc-open-athena-test/CC-SUPPLEMENTAL-2026-22-bis/20260522101936/warc/CC-SUPPLEMENTAL-2026-22-bis-20260522102012-20260522152012-00000.warc.gz</code>
 	 */
 	protected static final Pattern supplementalFilenameAnalyzer = Pattern.compile(
-			"^[^/]+/[^/]+/(CC-SUPPLEMENTAL-[^/]+)/(\\d+)/(crawldiagnostics|robotstxt|warc)/");
+			"^[^/]+/[^/]+/(CC-SUPPLEMENTAL-[^/]+)/segments/(\\d+)/(crawldiagnostics|robotstxt|warc)/");
 	/**
 	 * News crawl filename pattern:
 	 * <code>s3://commoncrawl/crawl-data/CC-NEWS/YYYY/MM/*.warc.gz</code> e.g.
@@ -83,6 +83,6 @@ public class CCWarcFilenameParser {
 			String crawl = String.format("CC-NEWS-%s-%s", m.group(1), m.group(2));
 			return new FilenameParts(crawl, m.group(3), "news-warc");
 		}
-		throw new FilenameParseError("Filename not parseable (tried main and news): " + filename);
+		throw new FilenameParseError("Filename not parseable (tried main, supplemental and news): " + filename);
 	}
 }

--- a/src/main/resources/schema/cc-index-schema-flat.json
+++ b/src/main/resources/schema/cc-index-schema-flat.json
@@ -265,7 +265,7 @@
     },
     {
       "name": "warc_record_offset",
-      "type": "integer",
+      "type": "long",
       "nullable": false,
       "metadata": {
         "description": "Offset of the WARC record",
@@ -275,7 +275,7 @@
     },
     {
       "name": "warc_record_length",
-      "type": "integer",
+      "type": "long",
       "nullable": false,
       "metadata": {
         "description": "Length of the WARC record",

--- a/src/main/resources/schema/cc-index-schema-nested.json
+++ b/src/main/resources/schema/cc-index-schema-nested.json
@@ -310,7 +310,7 @@
           },
           {
             "name": "record_offset",
-            "type": "integer",
+            "type": "long",
             "nullable": false,
             "metadata": {
               "description": "Offset of the WARC record",
@@ -320,7 +320,7 @@
           },
           {
             "name": "record_length",
-            "type": "integer",
+            "type": "long",
             "nullable": false,
             "metadata": {
               "description": "Length of the WARC record",

--- a/src/main/resources/schema/index-schema-simple-nested.json
+++ b/src/main/resources/schema/index-schema-simple-nested.json
@@ -287,7 +287,7 @@
           },
           {
             "name": "record_offset",
-            "type": "integer",
+            "type": "long",
             "nullable": false,
             "metadata": {
               "description": "Offset of the WARC record",
@@ -297,7 +297,7 @@
           },
           {
             "name": "record_length",
-            "type": "integer",
+            "type": "long",
             "nullable": false,
             "metadata": {
               "description": "Length of the WARC record",

--- a/src/main/resources/schema/index-schema-simple.json
+++ b/src/main/resources/schema/index-schema-simple.json
@@ -239,7 +239,7 @@
     },
     {
       "name": "warc_record_offset",
-      "type": "integer",
+      "type": "long",
       "nullable": false,
       "metadata": {
         "description": "Offset of the WARC record",
@@ -249,7 +249,7 @@
     },
     {
       "name": "warc_record_length",
-      "type": "integer",
+      "type": "long",
       "nullable": false,
       "metadata": {
         "description": "Length of the WARC record",

--- a/src/test/java/org/commoncrawl/spark/TestCCWarcFilenameParser.java
+++ b/src/test/java/org/commoncrawl/spark/TestCCWarcFilenameParser.java
@@ -34,6 +34,15 @@ public class TestCCWarcFilenameParser {
 	}
 
 	@Test
+	public void testSupplementalWarcFilename() throws FilenameParseError {
+		String filename = "projects/cc-open-athena-test/CC-SUPPLEMENTAL-2026-22/20260522101936/warc/CC-SUPPLEMENTAL-2026-22-bis-20260522102012-20260522152012-00000.warc.gz";
+		FilenameParts parts = CCWarcFilenameParser.getParts(filename);
+		assertEquals("CC-SUPPLEMENTAL-2026-22", parts.crawl);
+		assertEquals("20260522101936", parts.segment);
+		assertEquals("warc", parts.subset);
+	}
+
+	@Test
 	public void testMainWat() throws FilenameParseError {
 		String filename = "crawl-data/CC-MAIN-2018-47/segments/1542039741324.15/wat/CC-MAIN-20181113153141-20181113174452-00011.warc.wat.gz";
 		FilenameParts parts = CCWarcFilenameParser.getParts(filename);

--- a/src/test/java/org/commoncrawl/spark/TestCCWarcFilenameParser.java
+++ b/src/test/java/org/commoncrawl/spark/TestCCWarcFilenameParser.java
@@ -34,12 +34,21 @@ public class TestCCWarcFilenameParser {
 	}
 
 	@Test
-	public void testSupplementalWarcFilename() throws FilenameParseError {
-		String filename = "projects/cc-open-athena-test/CC-SUPPLEMENTAL-2026-22/segments/20260522204839/warc/CC-SUPPLEMENTAL-2026-22-20260522204937-20260523014937-00119.warc.gz";
+	public void testSupplementalWarcFilenameCrawlDiagnostics() throws FilenameParseError {
+		String filename = "projects/cc-open-athena-test/CC-SUPPLEMENTAL-2026-22/segments/20260522204839/crawldiagnostics/CC-SUPPLEMENTAL-2026-22-20260522204937-20260523014937-00119.warc.gz";
 		FilenameParts parts = CCWarcFilenameParser.getParts(filename);
 		assertEquals("CC-SUPPLEMENTAL-2026-22", parts.crawl);
 		assertEquals("20260522204839", parts.segment);
-		assertEquals("warc", parts.subset);
+		assertEquals("crawldiagnostics", parts.subset);
+	}
+
+		@Test
+	public void testSupplementalWarcFilenameRobotsTxt() throws FilenameParseError {
+		String filename = "projects/cc-open-athena-test/CC-SUPPLEMENTAL-2026-22/segments/20260522204839/robotstxt/CC-SUPPLEMENTAL-2026-22-20260522204937-20260523014937-00119.warc.gz";
+		FilenameParts parts = CCWarcFilenameParser.getParts(filename);
+		assertEquals("CC-SUPPLEMENTAL-2026-22", parts.crawl);
+		assertEquals("20260522204839", parts.segment);
+		assertEquals("robotstxt", parts.subset);
 	}
 
 	@Test

--- a/src/test/java/org/commoncrawl/spark/TestCCWarcFilenameParser.java
+++ b/src/test/java/org/commoncrawl/spark/TestCCWarcFilenameParser.java
@@ -35,10 +35,10 @@ public class TestCCWarcFilenameParser {
 
 	@Test
 	public void testSupplementalWarcFilename() throws FilenameParseError {
-		String filename = "projects/cc-open-athena-test/CC-SUPPLEMENTAL-2026-22/20260522101936/warc/CC-SUPPLEMENTAL-2026-22-bis-20260522102012-20260522152012-00000.warc.gz";
+		String filename = "projects/cc-open-athena-test/CC-SUPPLEMENTAL-2026-22/segments/20260522204839/warc/CC-SUPPLEMENTAL-2026-22-20260522204937-20260523014937-00119.warc.gz";
 		FilenameParts parts = CCWarcFilenameParser.getParts(filename);
 		assertEquals("CC-SUPPLEMENTAL-2026-22", parts.crawl);
-		assertEquals("20260522101936", parts.segment);
+		assertEquals("20260522204839", parts.segment);
 		assertEquals("warc", parts.subset);
 	}
 


### PR DESCRIPTION
This fix extends the WARC filename parser to other cases such as the SUPPLEMENTAL schema, and keeps the backward compatibility with the main crawl. 

This fix was made in order to support the cc-focus-crawl. 