### PR TITLE
feat(build): integrate Spotless code formatting check into CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
           cache: 'maven'
 
       - name: Build
-        run: mvn verify javadoc:aggregate
+        run: mvn verify javadoc:aggregate spotless:check

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>2.46.1</version>
 				<configuration>
 					<pom>
 						<!-- These are the defaults, you can override if you want -->


### PR DESCRIPTION
Run Spotless code formatting check into CI build.

Downgrade Spotless Maven plugin to stay compatible with JDK 11.