### PR TITLE
Add WARC-Record-ID column (#42)

### DIFF
--- a/src/main/java/org/commoncrawl/net/HostName.java
+++ b/src/main/java/org/commoncrawl/net/HostName.java
@@ -16,7 +16,6 @@
  */
 package org.commoncrawl.net;
 
-import java.io.UnsupportedEncodingException;
 import java.net.IDN;
 import java.net.InetAddress;
 import java.net.URI;

--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -43,6 +43,7 @@ public class CCIndex2Table extends IndexTable {
 		String redirect;
 		String digest;
 		String mime, mimeDetected;
+		String recordid;
 		String filename;
 		int offset, length;
 		short status;
@@ -60,6 +61,7 @@ public class CCIndex2Table extends IndexTable {
 			mime = getString("mime");
 			mimeDetected = getString("mime-detected");
 
+			recordid = getString("recordid");
 			filename = getString("filename");
 			offset = getInt("offset");
 			length = getInt("length");
@@ -102,7 +104,7 @@ public class CCIndex2Table extends IndexTable {
 					RowFactory.create(cdx.timestamp, cdx.status, cdx.redirect), //
 					RowFactory
 							.create(cdx.digest, cdx.mime, cdx.mimeDetected, cdx.charset, cdx.languages, cdx.truncated), //
-					RowFactory.create(cdx.filename, cdx.offset, cdx.length, cdx.segment), //
+					RowFactory.create(cdx.recordid, cdx.filename, cdx.offset, cdx.length, cdx.segment), //
 					cdx.crawl,
 					cdx.subset);
 		} else {
@@ -142,6 +144,8 @@ public class CCIndex2Table extends IndexTable {
 					cdx.languages,
 					// content (WARC record payload) truncated (since CC-MAIN-2019-47)
 					cdx.truncated,
+					// WARC record headers
+					cdx.recordid,
 					// WARC record location
 					cdx.filename,
 					cdx.offset,

--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -26,8 +26,8 @@ import org.apache.commons.cli.Options;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.commoncrawl.spark.util.CCWarcFilenameParser;
-import org.commoncrawl.spark.util.CCWarcFilenameParser.FilenameParts;
 import org.commoncrawl.spark.util.CCWarcFilenameParser.FilenameParseError;
+import org.commoncrawl.spark.util.CCWarcFilenameParser.FilenameParts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -17,6 +17,8 @@
 package org.commoncrawl.spark;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -43,7 +45,7 @@ public class CCIndex2Table extends IndexTable {
 		String redirect;
 		String digest;
 		String mime, mimeDetected;
-		String recordid;
+		byte[] recordid;
 		String filename;
 		int offset, length;
 		short status;
@@ -61,7 +63,15 @@ public class CCIndex2Table extends IndexTable {
 			mime = getString("mime");
 			mimeDetected = getString("mime-detected");
 
-			recordid = getString("recordid");
+			recordid = null;
+			String id = getString("recordid");
+			if (id != null) {
+				UUID uuid = UUID.fromString(id);
+				recordid = new byte[16];
+				ByteBuffer.wrap(recordid)
+						.putLong(uuid.getMostSignificantBits())
+						.putLong(uuid.getLeastSignificantBits());
+			}
 			filename = getString("filename");
 			offset = getInt("offset");
 			length = getInt("length");

--- a/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
+++ b/src/main/java/org/commoncrawl/spark/CCIndex2Table.java
@@ -154,7 +154,7 @@ public class CCIndex2Table extends IndexTable {
 					cdx.languages,
 					// content (WARC record payload) truncated (since CC-MAIN-2019-47)
 					cdx.truncated,
-					// WARC record headers
+					// WARC-Record-ID (since CC-MAIN-2026-30)
 					cdx.recordid,
 					// WARC record location
 					cdx.filename,

--- a/src/main/java/org/commoncrawl/spark/util/NullOutputCommitter.java
+++ b/src/main/java/org/commoncrawl/spark/util/NullOutputCommitter.java
@@ -16,11 +16,11 @@
  */
 package org.commoncrawl.spark.util;
 
+import java.io.IOException;
+
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-
-import java.io.IOException;
 
 public class NullOutputCommitter extends OutputCommitter {
 

--- a/src/main/resources/schema/cc-index-schema-flat.json
+++ b/src/main/resources/schema/cc-index-schema-flat.json
@@ -254,6 +254,17 @@
       }
     },
     {
+      "name": "warc_record_id",
+      "type": "string",
+      "nullable": true,
+      "metadata": {
+        "description": "UUID of the WARC record (WARC-Record-ID)",
+        "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d",
+        "since": "CC-MAIN-2026-21",
+        "fromCDX": "recordid"
+      }
+    },
+    {
       "name": "warc_filename",
       "type": "string",
       "nullable": false,

--- a/src/main/resources/schema/cc-index-schema-flat.json
+++ b/src/main/resources/schema/cc-index-schema-flat.json
@@ -255,11 +255,11 @@
     },
     {
       "name": "warc_record_id",
-      "type": "string",
+      "type": "binary",
       "nullable": true,
       "metadata": {
         "description": "UUID of the WARC record (WARC-Record-ID)",
-        "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d",
+        "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d (stringified)",
         "since": "CC-MAIN-2026-21",
         "fromCDX": "recordid"
       }

--- a/src/main/resources/schema/cc-index-schema-flat.json
+++ b/src/main/resources/schema/cc-index-schema-flat.json
@@ -256,11 +256,11 @@
     {
       "name": "warc_record_id",
       "type": "binary",
-      "nullable": true,
+      "nullable": false,
       "metadata": {
         "description": "UUID of the WARC record (WARC-Record-ID)",
         "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d (stringified)",
-        "since": "CC-MAIN-2026-21",
+        "since": "CC-MAIN-2026-30",
         "fromCDX": "recordid"
       }
     },

--- a/src/main/resources/schema/cc-index-schema-nested.json
+++ b/src/main/resources/schema/cc-index-schema-nested.json
@@ -300,11 +300,11 @@
         "fields": [
           {
             "name": "record_id",
-            "type": "string",
+            "type": "binary",
             "nullable": true,
             "metadata": {
               "description": "UUID of the WARC record (WARC-Record-ID)",
-              "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d",
+              "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d (stringified)",
               "since": "CC-MAIN-2026-21",
               "fromCDX": "recordid"
             }

--- a/src/main/resources/schema/cc-index-schema-nested.json
+++ b/src/main/resources/schema/cc-index-schema-nested.json
@@ -301,11 +301,11 @@
           {
             "name": "record_id",
             "type": "binary",
-            "nullable": true,
+            "nullable": false,
             "metadata": {
               "description": "UUID of the WARC record (WARC-Record-ID)",
               "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d (stringified)",
-              "since": "CC-MAIN-2026-21",
+              "since": "CC-MAIN-2026-30",
               "fromCDX": "recordid"
             }
           },

--- a/src/main/resources/schema/cc-index-schema-nested.json
+++ b/src/main/resources/schema/cc-index-schema-nested.json
@@ -299,6 +299,17 @@
         "type": "struct",
         "fields": [
           {
+            "name": "record_id",
+            "type": "string",
+            "nullable": true,
+            "metadata": {
+              "description": "UUID of the WARC record (WARC-Record-ID)",
+              "example": "019d6d22-5cf4-7ad9-8a24-81690cf43c7d",
+              "since": "CC-MAIN-2026-21",
+              "fromCDX": "recordid"
+            }
+          },
+          {
             "name": "filename",
             "type": "string",
             "nullable": false,

--- a/src/script/convert_url_index.sh
+++ b/src/script/convert_url_index.sh
@@ -55,6 +55,7 @@ $SPARK_HOME/bin/spark-submit \
     --executor-cores $EXECUTOR_CORES \
     --executor-memory $EXECUTOR_MEM \
     --conf spark.hadoop.parquet.enable.dictionary=true \
+    --conf 'spark.hadoop.parquet.enable.dictionary#warc_record_id=false' \
     --conf spark.sql.parquet.filterPushdown=true \
     --conf spark.sql.parquet.mergeSchema=false \
     --conf spark.sql.hive.metastorePartitionPruning=true \

--- a/src/script/convert_url_index.sh
+++ b/src/script/convert_url_index.sh
@@ -56,6 +56,7 @@ $SPARK_HOME/bin/spark-submit \
     --executor-memory $EXECUTOR_MEM \
     --conf spark.hadoop.parquet.enable.dictionary=true \
     --conf 'spark.hadoop.parquet.enable.dictionary#warc_record_id=false' \
+    --conf 'spark.hadoop.parquet.enable.dictionary#warc.record_id=false' \
     --conf spark.sql.parquet.filterPushdown=true \
     --conf spark.sql.parquet.mergeSchema=false \
     --conf spark.sql.hive.metastorePartitionPruning=true \

--- a/src/sql/athena/cc-index-create-table-flat.sql
+++ b/src/sql/athena/cc-index-create-table-flat.sql
@@ -32,6 +32,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS ccindex (
   content_charset               STRING,
   content_languages             STRING,
   content_truncated             STRING,
+  warc_record_id                BINARY,
   warc_filename                 STRING,
   warc_record_offset            INT,
   warc_record_length            INT,

--- a/src/sql/athena/cc-index-create-table-nested.sql
+++ b/src/sql/athena/cc-index-create-table-nested.sql
@@ -9,7 +9,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS ccindex (
   url     STRUCT<surtkey:STRING, url:STRING, host:STRUCT<name:STRING, tld:STRING, 2nd_last_part:STRING, 3rd_last_part:STRING, 4th_last_part:STRING, 5th_last_part:STRING, registry_suffix:STRING, registered_domain:STRING, private_suffix:STRING, private_domain:STRING, name_reversed:STRING>, protocol:STRING, port:INT, path:STRING, query:STRING>,
   fetch   STRUCT<time:TIMESTAMP, status:SMALLINT, redirect:STRING>,
   content STRUCT<digest:STRING, mime_type:STRING, mime_detected:STRING, charset:STRING, languages:STRING, truncated:STRING>,
-  warc    STRUCT<filename:STRING, record_offset:INT, record_length:INT, segment:STRING>)
+  warc    STRUCT<record_id:BINARY, filename:STRING, record_offset:INT, record_length:INT, segment:STRING>)
 PARTITIONED BY(crawl STRING, subset STRING)
 STORED AS parquet
 LOCATION 's3://path_to_table/';

--- a/src/test/java/org/commoncrawl/spark/TestCCIndex2Table.java
+++ b/src/test/java/org/commoncrawl/spark/TestCCIndex2Table.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 public class TestCCIndex2Table extends TestIndexTableBase {
 
 	protected String getCdxLine() {
-		return "org,commoncrawl)/faq 20220127163355 {\"url\": \"https://commoncrawl.org/faq/\", \"mime\": \"text/html\", \"mime-detected\": \"text/html\", \"status\": \"301\", \"digest\": \"3I42H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ\", \"length\": \"958\", \"offset\": \"6946714\", \"filename\": \"crawl-data/CC-MAIN-2022-05/segments/1642320305277.88/crawldiagnostics/CC-MAIN-20220127163150-20220127193150-00502.warc.gz\", \"redirect\": \"/big-picture/frequently-asked-questions/\"}";
+		return "org,commoncrawl)/faq 20260711045728 {\"url\": \"https://commoncrawl.org/faq\", \"mime\": \"text/html\", \"mime-detected\": \"text/html\", \"status\": \"200\", \"digest\": \"DIGO3UYP5E4RCVMRIJ6A7523DBTXRRGO\", \"length\": \"10201\", \"offset\": \"129368320\", \"filename\": \"crawl-data/CC-MAIN-2026-30/segments/1783663951473.63/warc/CC-MAIN-20260711043148-20260711073148-00793.warc.gz\", \"charset\": \"UTF-8\", \"languages\": \"eng\", \"recordid\": \"019f4f89-a39c-717a-8ad3-2371c5d248fe\"}";
 	}
 
 	@Test


### PR DESCRIPTION
Add WARC-Record-ID column, closes #42.

Add the new column `warc_record_id` holding the WARC-Record-ID as BINARY type.

